### PR TITLE
Fix variable name

### DIFF
--- a/src/MarketplaceWebServiceOrders/Model/ResponseHeaderMetadata.php
+++ b/src/MarketplaceWebServiceOrders/Model/ResponseHeaderMetadata.php
@@ -29,12 +29,12 @@ class MarketplaceWebServiceOrders_Model_ResponseHeaderMetadata {
   private $metadata = array();
 
   public function __construct($requestId = null, $responseContext = null, $timestamp = null,
-                              $quotaMax = null, $quotaMax = null, $quotaResetsAt = null) {
+                              $quotaMax = null, $quotaRemaining = null, $quotaResetsAt = null) {
     $this->metadata[self::REQUEST_ID] = $requestId;
     $this->metadata[self::RESPONSE_CONTEXT] = $responseContext;
     $this->metadata[self::TIMESTAMP] = $timestamp;
     $this->metadata[self::QUOTA_MAX] = $quotaMax;
-    $this->metadata[self::QUOTA_REMAINING] = $quotaMax;
+    $this->metadata[self::QUOTA_REMAINING] = $quotaRemaining;
     $this->metadata[self::QUOTA_RESETS_AT] = $quotaResetsAt;
   }
 


### PR DESCRIPTION
With PHP7 it throws a critical: Compile Error: Redefinition of parameter $quotaMax