### PR TITLE
Added @param declaration for all params in construct

### DIFF
--- a/src/MarketplaceWebServiceOrders/Client.php
+++ b/src/MarketplaceWebServiceOrders/Client.php
@@ -382,7 +382,10 @@ class MarketplaceWebServiceOrders_Client implements MarketplaceWebServiceOrders_
      *
      * @param string $awsAccessKeyId AWS Access Key ID
      * @param string $awsSecretAccessKey AWS Secret Access Key
+     * @param string $applicationName Application Name for User-Agent header
+     * @param string $applicationVersion Application Version for User-Agent header
      * @param array $config configuration options.
+     *
      * Valid configuration options are:
      * <ul>
      * <li>ServiceURL</li>


### PR DESCRIPTION
When compiling in PHP 7 it throws a type error because it expects the 3rd param for `__construct` of `MarketplaceWebServiceOrders_Client` to be an array but it receives a string. This is because 2 of the parameters are missing from the docblock declaration.